### PR TITLE
Rename log.gz file to log

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
+++ b/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
@@ -103,6 +103,11 @@ public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
                 // XXX try multiple times because Windows?
                 if (!log.delete()) {
                     LOGGER.log(Level.WARNING, String.format("Failed to delete build log of %s after compression", run));
+                } else {
+                	File gzLogFile = new File(log.getParentFile(), gzippedLogName);
+                	if ( gzLogFile.renameTo(log) ) {
+                		 LOGGER.log(Level.WARNING, String.format("Failed to rename build log after compression"));
+                	}
                 }
             }
         }


### PR DESCRIPTION
Now jenkins display only log file without any extension. 
After the delete, rename the file to source.